### PR TITLE
Dependencies path fix

### DIFF
--- a/bin/Makefile
+++ b/bin/Makefile
@@ -41,6 +41,9 @@ clean_node:
 
 fetch: $(NODEDIR)
 
+inject: $(NODEDIR)
+	@node $(NAD_BIN_DIR)/nad-inject.js $(TARGET) $(CWD) $(NODEDIR)
+
 open:
 	@open $(NODEDIR)node.xcodeproj
 

--- a/bin/nad.sh
+++ b/bin/nad.sh
@@ -51,7 +51,7 @@ main() {
   local cmd="$1"
   shift
   case $cmd in
-    init | configure | install | fetch | clean |  \
+    init | configure | install | fetch | inject | clean |  \
     build | restore | info | open | fix | help )
       cmd="nad_$cmd"
       ;;
@@ -102,6 +102,13 @@ nad_fetch() {
   ensure_nadconfig_mk
   log info "Fetching Node.js source"
   nad_make fetch
+}
+
+nad_inject() {
+  ensure_binding_gyp
+  ensure_nadconfig_mk
+  log info "Injecting code into Node.js source"
+  nad_make inject
 }
 
 nad_install() {

--- a/lib/adapt-node_gyp.js
+++ b/lib/adapt-node_gyp.js
@@ -29,6 +29,7 @@ function adaptBindingGyp(projectDir, nodeDir, binding_gyp) {
     // add binding.gyp to sources
     t.sources.push('binding.gyp');
     if (t.sources) t.sources = t.sources.map(fixPath);
+    if (t.dependencies) t.dependencies = t.dependencies.map(fixPath);
     if (t.include_dirs) t.include_dirs = t.include_dirs.map(fixPath);
   }
 


### PR DESCRIPTION
Need to resolve the path to any dependency gyp files, relative to the node directory.
e.g. binding.gyp could have:
'dependencies': [
  'deps/libzookeeper.gyp:zkst',
]

Unrelated, but also exposed the `inject` command since it was referenced in the docs.
It's useful for testing inject without re-building node.